### PR TITLE
Endtime needs to be ommitted or Event Updates fail

### DIFF
--- a/event.go
+++ b/event.go
@@ -20,7 +20,7 @@ type Event struct {
 	StartTime int64 `json:"startTime"`
 
 	// EndTime is the end time, in epoch milliseconds, of the Event
-	EndTime int64 `json:"endTime"`
+	EndTime int64 `json:"endTime,omitempty"`
 
 	// Tags are the tags associated with the Event
 	Tags []string `json:"tags"`


### PR DESCRIPTION
In the current code if you issue an Update on an event, you get the following error:

```
server returned 400 Bad Request\n{\"result\":\"ERROR\",\"message\":\"Closed event: (test |
test deployed | by  | in ) end time 0 cannot be <= event start time 1552938143000\",\"code\":400}
```

Our solution locally is to change this value to be omitempty, which means that on being set to 0 the field just doesn't exist.