### PR TITLE
Parse Error types from QueryResult

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	AlertTypeThreshold = "THRESHOLD"
-	AlertTypeClassic = "CLASSIC"
+	AlertTypeClassic   = "CLASSIC"
 )
 
 // Alert represents a single Wavefront Alert

--- a/fixtures/failed-query.json
+++ b/fixtures/failed-query.json
@@ -1,0 +1,5 @@
+{
+  "query": "ts(servers.load.load.longterm, source=server1.example.net)",
+  "errorType": "QueryExecutionFailed",
+  "errorMessage": "Terminating Query to save resources"
+}

--- a/query.go
+++ b/query.go
@@ -78,6 +78,12 @@ type QueryResponse struct {
 	Granularity int            `json:"granularity"`
 	Hosts       []string       `json:"hostsUsed"`
 	Warnings    string         `json:"warnings"`
+
+	// ErrType : ref https://code.vmware.com/apis/714/wavefront-rest#/Query/queryApi
+	ErrType string `json:"errorType"`
+
+	// ErrMessage : ref https://code.vmware.com/apis/714/wavefront-rest#/Query/queryApi
+	ErrMessage string `json:"errorMessage"`
 }
 
 // DataPoint represents a single timestamp/value data point as returned


### PR DESCRIPTION
Ref: https://code.vmware.com/apis/714/wavefront-rest#/Query/queryApi.
The model for QueryResult here says there can be two optional string
types which represent errors:

*  errType
*  errMessage

I have frequently seen wavefront return statuses like 'Query Execution
Terminated', in errType fields. Without these types defined, there is
no way for clients to know the query execution failed on the server.

Fixes #31 