### PR TITLE
Allow configuration of client tls

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,9 @@ type Config struct {
 	// https://golang.org/src/net/http/client.go
 	Timeout time.Duration
 
+	// https://golang.org/src/net/http/client.go
+	TLSClientConfig *tls.Config
+
 	// SET HTTP Proxy configuration
 	HttpProxy string
 
@@ -69,17 +72,18 @@ func NewClient(config *Config) (*Client, error) {
 	h := &http.Client{
 		Timeout: config.Timeout,
 		Transport: &http.Transport{
-			TLSNextProto: map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+			TLSClientConfig: config.TLSClientConfig,
+			TLSNextProto:    map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
 		},
 	}
 
 	// need to disable http/2 as it doesn't play nicely with nginx
 	// to do so we set TLSNextProto to an empty, non-nil map
 	c := &Client{
-		Config: config,
-		BaseURL: baseURL,
+		Config:     config,
+		BaseURL:    baseURL,
 		httpClient: h,
-		debug: false,
+		debug:      false,
 	}
 
 	// ENABLE HTTP Proxy

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,8 @@
 package wavefront
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -122,6 +124,67 @@ func TestClientPost(t *testing.T) {
 	}
 
 	req, err := client.NewRequest("POST", "test/thing", params, body)
+	if err != nil {
+		t.Fatal("error creating request:", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal("error executing request:", err)
+	}
+	output, _ := ioutil.ReadAll(resp)
+	fmt.Println(string(output))
+}
+
+func TestClientTLSConfig(t *testing.T) {
+	params := &map[string]string{
+		"s":                      "144242525262",
+		"e":                      "142252272822",
+		"includeObsoleteMetrics": "true",
+	}
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+
+		if r.URL.Path != "/api/v2/test/thing" {
+			t.Errorf("request path, expected /api/v2/test/thing, got %s", r.URL.Path)
+		}
+
+		if header, ok := r.Header["Authorization"]; ok {
+			if header[0] != "Bearer 123456789" {
+				t.Errorf("Authorization header, expected 'Bearer 123456789', got %s", header[0])
+			}
+		} else {
+			t.Errorf("no Authorization header set")
+		}
+
+		for k, v := range *params {
+			if r.Form.Get(k) != v {
+				t.Errorf("request param, expected %s, got %s", v, r.Form.Get(k))
+			}
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	defer srv.Close()
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	tlsConfig := tls.Config{
+		RootCAs: pool,
+	}
+
+	client, err := NewClient(&Config{
+		Address:         strings.TrimLeft(srv.URL, "https://"),
+		Token:           "123456789",
+		TLSClientConfig: &tlsConfig,
+	})
+
+	if err != nil {
+		t.Fatal("error initiating client:", err)
+	}
+
+	req, err := client.NewRequest("GET", "test/thing", params, nil)
 	if err != nil {
 		t.Fatal("error creating request:", err)
 	}


### PR DESCRIPTION
Similar to #33, this adds support for specifying TLS client configuration for the `http.Client`.