### PR TITLE
Preserve http.Client transport option when setting proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -70,12 +70,14 @@ func NewClient(config *Config) (*Client, error) {
 
 	// Added timeout to http client
 	// Timeout of zero means no timeout
+	t := &http.Transport{
+		TLSClientConfig: config.TLSClientConfig,
+		TLSNextProto:    map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
+	}
+
 	h := &http.Client{
-		Timeout: config.Timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: config.TLSClientConfig,
-			TLSNextProto:    map[string]func(authority string, c *tls.Conn) http.RoundTripper{},
-		},
+		Timeout:   config.Timeout,
+		Transport: t,
 	}
 
 	// need to disable http/2 as it doesn't play nicely with nginx
@@ -90,9 +92,7 @@ func NewClient(config *Config) (*Client, error) {
 	// ENABLE HTTP Proxy
 	if config.HttpProxy != "" {
 		proxyUrl, _ := url.Parse(config.HttpProxy)
-		c.httpClient.Transport = &http.Transport{
-			Proxy: http.ProxyURL(proxyUrl),
-		}
+		t.Proxy = http.ProxyURL(proxyUrl)
 	}
 
 	//For testing ONLY

--- a/client_test.go
+++ b/client_test.go
@@ -195,3 +195,32 @@ func TestClientTLSConfig(t *testing.T) {
 	output, _ := ioutil.ReadAll(resp)
 	fmt.Println(string(output))
 }
+
+func TestClientTLSWithProxy(t *testing.T) {
+	pool := x509.NewCertPool()
+	tlsConfig := tls.Config{
+		RootCAs: pool,
+	}
+	httpProxy := "http://example.com:8080"
+
+	client, err := NewClient(&Config{
+		Address:         "example.org",
+		Token:           "123456789",
+		TLSClientConfig: &tlsConfig,
+		HttpProxy:       httpProxy,
+	})
+
+	if err != nil {
+		t.Fatal("error initiating client:", err)
+	}
+
+	transport := client.httpClient.Transport.(*http.Transport)
+	if transport.TLSClientConfig != &tlsConfig {
+		t.Fatal("TLS Client Config not preserved")
+	}
+
+	transportProxy, _ := transport.Proxy(nil)
+	if httpProxy != transportProxy.String() {
+		t.Fatal("HttpProxy not preserved")
+	}
+}


### PR DESCRIPTION
This enables simultaneous use of both a custom TLS client configuration with an HTTP proxy.